### PR TITLE
In-place swap of wasm in contract store

### DIFF
--- a/tests/wasm_subst/test.sh
+++ b/tests/wasm_subst/test.sh
@@ -45,3 +45,17 @@ cleos create account eosio helloworld EOS7Sp9Z1ahCNpVGGsSPRJCtYDTg8YdqEzt63s7y8m
 cleos set contract helloworld . helloworld.wasm helloworld.abi -p helloworld@active 
 
 cleos push action helloworld hi "[]" -p eosio@active
+
+sleep 1
+
+cleos push action helloworld hi "[]" -p eosio@active
+
+sleep 1
+
+cleos push action helloworld hi "[]" -p eosio@active
+
+sleep 1
+
+cleos push action helloworld hi "[]" -p eosio@active
+
+sleep 1


### PR DESCRIPTION
Stop doing the execution ourselves and just do in-place swapping of the contract wasm in the internal nodeos database.

This allows us to use all the already created nodeos machinery for exection which after testing shows it solves our `acess violation` errors.

Closes #10 