### PR TITLE
Override on-chain max transaction time value for EVM reverts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ option(ENABLE_WEXTRA "Enable `-Wextra` compilation flag." Off)
 
 set(SPLUGIN_VERSION_MAJOR 1)
 set(SPLUGIN_VERSION_MINOR 0)
-set(SPLUGIN_VERSION_PATCH 1)
+set(SPLUGIN_VERSION_PATCH 2)
 
 set(
     VERSION_FULL

--- a/plugins/subst_plugin/subst_plugin.cpp
+++ b/plugins/subst_plugin/subst_plugin.cpp
@@ -14,9 +14,102 @@ namespace eosio {
         std::map<fc::sha256, fc::sha256> enabled_substitutions;
 
         chainbase::database* db;
+        controller* control;
+        producer_plugin* prod_plug;
 
         fc::http_client httpc;
         appbase::variables_map app_options;
+
+        bool override_tx_time = false;
+        bool should_perform_override = false;
+        uint32_t override_time = 300;
+
+        void init(chain_plugin* chain, producer_plugin* producer, const variables_map& options) {
+            prod_plug = producer;
+            const auto runtime_options = prod_plug->get_runtime_options();
+            if (runtime_options.max_transaction_time.has_value())
+                override_time = runtime_options.max_transaction_time.value();
+
+            app_options = options;
+
+            control = &chain->chain();
+            db = &control->mutable_db();
+
+            try {
+                control->get_wasm_interface().substitute_apply = [&](
+                    const eosio::chain::digest_type& code_hash,
+                    uint8_t vm_type, uint8_t vm_version,
+                    eosio::chain::apply_context& context
+                ) {
+                    return substitute_apply(code_hash, vm_type, vm_version, context);
+                };
+                ilog("installed substitution hook");
+
+                override_tx_time = (options.count("override-max-tx-time") &&
+                                           options["override-max-tx-time"].as<bool>());
+                should_perform_override = override_tx_time;
+
+                ilog("should_perform_override: {over}", ("over",should_perform_override));
+
+                std::string chain_id = control->get_chain_id();
+
+                if (options.count("subst-by-name")) {
+                    auto substs = options.at("subst-by-name").as<vector<string>>();
+                    for (auto& s : substs) {
+                        std::vector<std::string> v;
+                        boost::split(v, s, boost::is_any_of(":"));
+
+                        EOS_ASSERT(
+                            v.size() == 2,
+                            fc::invalid_arg_exception,
+                            "Invalid value ${s} for --subst-by-name"
+                            " format is {account_name}:{path_to_wasm}", ("s", s)
+                        );
+
+                        auto account_name = v[0];
+                        auto new_code_path = v[1];
+
+                        std::vector<uint8_t> new_code = eosio::vm::read_wasm(new_code_path);
+                        register_substitution(account_name, new_code);
+                    }
+                }
+                if (options.count("subst-by-hash")) {
+                    auto substs = options.at("subst-by-hash").as<vector<string>>();
+                    for (auto& s : substs) {
+                        std::vector<std::string> v;
+                        boost::split(v, s, boost::is_any_of(":"));
+
+                        EOS_ASSERT(
+                            v.size() == 2,
+                            fc::invalid_arg_exception,
+                            "Invalid value ${s} for --subst-by-hash"
+                            " format is {contract_hash}:{path_to_wasm}", ("s", s)
+                        );
+
+                        auto contract_hash = v[0];
+                        auto new_code_path = v[1];
+
+                        std::vector<uint8_t> new_code = eosio::vm::read_wasm(new_code_path);
+                        register_substitution(contract_hash, new_code);
+                    }
+                }
+                if (options.count("subst-manifest")) {
+                    auto substs = options.at("subst-manifest").as<vector<string>>();
+                    for (auto& s : substs) {
+                        auto manifest_url = fc::url(s);
+                        EOS_ASSERT(
+                            manifest_url.proto() == "http",
+                            fc::invalid_arg_exception,
+                            "Only http protocol supported for now."
+                        );
+                        load_remote_manifest(chain_id, manifest_url);
+                    }
+                }
+
+                debug_print_maps();
+
+            } FC_LOG_AND_RETHROW()
+        }
 
         void debug_print_maps() {
             // print susbtitution maps for debug
@@ -77,6 +170,20 @@ namespace eosio {
         ) {
             eosio::name receiver = context.get_receiver();
             auto act = context.get_action();
+
+            if (override_tx_time) {
+                if (should_perform_override) pwn_gpo();
+
+                if (receiver == eosio::name("eosio") &&
+                    act.name == eosio::name("setparams")) {
+
+                    should_perform_override = true;
+                    ilog(
+                        "setparams detected at ${bnum}, pwning gpo on next action",
+                        ("bnum", control->pending_block_num())
+                    );
+                }
+            }
 
             if (receiver == eosio::name("eosio") &&
                 act.name == eosio::name("setcode")) {
@@ -217,6 +324,52 @@ namespace eosio {
                 ilog("manifest found but chain id not present.");
             }
         }
+
+        void pwn_gpo() {
+            const auto& gpo = control->get_global_properties();
+            const auto override_time_us = override_time * 1000;
+            const auto max_block_cpu_usage = gpo.configuration.max_transaction_cpu_usage;
+            // auto pwnd_options = prod_plug->get_runtime_options();
+            db->modify(gpo, [&](auto& dgp) {
+                // pwnd_options.max_transaction_time = override_time;
+                dgp.configuration.max_transaction_cpu_usage = override_time_us;
+                ilog(
+                    "new max_trx_cpu_usage value: ${pwnd_value}",
+                    ("pwnd_value", gpo.configuration.max_transaction_cpu_usage)
+                );
+                if (override_time_us > max_block_cpu_usage) {
+                    ilog(
+                        "override_time (${otime}us) is > max_block_cpu_usage (${btime}us), overriding as well",
+                        ("otime", override_time_us)("btime", max_block_cpu_usage)
+                    );
+                    dgp.configuration.max_block_cpu_usage = override_time_us;
+                    // pwnd_options.max_block_cpu_usage = override_time_us;
+                }
+                should_perform_override = false;
+                ilog("pwnd global_property_object!");
+                // uint64_t CPU_TARGET = EOS_PERCENT(override_time_us, gpo.configuration.target_block_cpu_usage_pct);
+                // auto& resource_limits = control->get_mutable_resource_limits_manager();
+                // resource_limits.set_block_parameters(
+                //     {
+                //         CPU_TARGET,
+                //         override_time_us,
+                //         chain::config::block_cpu_usage_average_window_ms / chain::config::block_interval_ms,
+                //         chain::config::maximum_elastic_resource_multiplier,
+                //         {99, 100}, {1000, 999}
+                //     },
+                //     {
+                //         EOS_PERCENT(gpo.configuration.max_block_net_usage, gpo.configuration.target_block_net_usage_pct),
+                //         gpo.configuration.max_block_net_usage,
+                //         chain::config::block_size_average_window_ms / chain::config::block_interval_ms,
+                //         chain::config::maximum_elastic_resource_multiplier,
+                //         {99, 100}, {1000, 999}
+                //     }
+                // );
+                // ilog("updated block resource limits!");
+                // prod_plug->update_runtime_options(pwnd_options);
+                // ilog("updated producer_plugin runtime_options");
+            });
+        }
     };  // subst_plugin_impl
 
     subst_plugin::subst_plugin() :
@@ -244,85 +397,16 @@ namespace eosio {
         options(
             "subst-manifest", bpo::value<vector<string>>()->composing(),
             "url. load susbtitution information from a remote json file.");
+        options(
+            "override-max-tx-time", boost::program_options::bool_switch(),
+            "Override on chain max-transaction-time with local producer_plugin config.");
     }
 
     void subst_plugin::plugin_initialize(const variables_map& options) {
         auto* chain_plug = app().find_plugin<chain_plugin>();
-        auto& control = chain_plug->chain();
+        auto* prod_plug = app().find_plugin<producer_plugin>();
 
-        try {
-            control.get_wasm_interface().substitute_apply = [this](
-                const eosio::chain::digest_type& code_hash,
-                uint8_t vm_type, uint8_t vm_version,
-                eosio::chain::apply_context& context
-            ) {
-                return this->my->substitute_apply(code_hash, vm_type, vm_version, context);
-            };
-
-            my->db = &control.mutable_db();
-
-            my->app_options = options;
-
-            ilog("installed substitution hook");
-
-            std::string chain_id = control.get_chain_id();
-
-            if (my->app_options.count("subst-by-name")) {
-                auto substs = my->app_options.at("subst-by-name").as<vector<string>>();
-                for (auto& s : substs) {
-                    std::vector<std::string> v;
-                    boost::split(v, s, boost::is_any_of(":"));
-
-                    EOS_ASSERT(
-                        v.size() == 2,
-                        fc::invalid_arg_exception,
-                        "Invalid value ${s} for --subst-by-name"
-                        " format is {account_name}:{path_to_wasm}", ("s", s)
-                    );
-
-                    auto account_name = v[0];
-                    auto new_code_path = v[1];
-
-                    std::vector<uint8_t> new_code = eosio::vm::read_wasm(new_code_path);
-                    my->register_substitution(account_name, new_code);
-                }
-            }
-            if (my->app_options.count("subst-by-hash")) {
-                auto substs = my->app_options.at("subst-by-hash").as<vector<string>>();
-                for (auto& s : substs) {
-                    std::vector<std::string> v;
-                    boost::split(v, s, boost::is_any_of(":"));
-
-                    EOS_ASSERT(
-                        v.size() == 2,
-                        fc::invalid_arg_exception,
-                        "Invalid value ${s} for --subst-by-hash"
-                        " format is {contract_hash}:{path_to_wasm}", ("s", s)
-                    );
-
-                    auto contract_hash = v[0];
-                    auto new_code_path = v[1];
-
-                    std::vector<uint8_t> new_code = eosio::vm::read_wasm(new_code_path);
-                    my->register_substitution(contract_hash, new_code);
-                }
-            }
-            if (my->app_options.count("subst-manifest")) {
-                auto substs = my->app_options.at("subst-manifest").as<vector<string>>();
-                for (auto& s : substs) {
-                    auto manifest_url = fc::url(s);
-                    EOS_ASSERT(
-                        manifest_url.proto() == "http",
-                        fc::invalid_arg_exception,
-                        "Only http protocol supported for now."
-                    );
-                    my->load_remote_manifest(chain_id, manifest_url);
-                }
-            }
-
-            my->debug_print_maps();
-
-        } FC_LOG_AND_RETHROW()
+        my->init(chain_plug, prod_plug, options);
     }  // subst_plugin::plugin_initialize
 
     void subst_plugin::plugin_startup() {}

--- a/plugins/subst_plugin/subst_plugin.hpp
+++ b/plugins/subst_plugin/subst_plugin.hpp
@@ -10,12 +10,15 @@
 
 #include <eosio/vm/backend.hpp>
 
+#include <eosio/chain/config.hpp>
 #include <eosio/chain/controller.hpp>
 #include <eosio/chain/application.hpp>
 #include <eosio/chain/apply_context.hpp>
 #include <eosio/chain/contract_types.hpp>
 #include <eosio/chain/transaction_context.hpp>
 #include <eosio/chain_plugin/chain_plugin.hpp>
+#include <eosio/producer_plugin/producer_plugin.hpp>
+#include <eosio/chain/global_property_object.hpp>
 
 
 namespace http = boost::beast::http;


### PR DESCRIPTION
First attempt at solving #21, tested using a modified version of the `eosmechaincs` contracts (https://github.com/guilledk/evmmechanics) and deploying on testnet i could confirm a node running the tx time override could get out of the on chain limit, jt reported that when evm guys used it to perform multicalls it still didnt work, which makes me think maybe this multicall calls are not read only.

Also moved config opts parsing to subst_plugin_impl class.